### PR TITLE
Remove duplicate NuxtLayout wrapper

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -3,7 +3,4 @@
     <NuxtRouteAnnouncer />
     <NuxtPage />
   </NuxtLayout>
-    <NuxtLayout>
-      <NuxtPage />
-    </NuxtLayout>
 </template>


### PR DESCRIPTION
## Summary
- remove the extra NuxtLayout wrapper from the app template so that NuxtRouteAnnouncer and NuxtPage are inside a single layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d334ba567883268214917528b985e9