### PR TITLE
Add Vitest config with Nuxt path aliases

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+const projectRoot = fileURLToPath(new URL('./', import.meta.url))
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  resolve: {
+    alias: {
+      '~': projectRoot,
+      '@': projectRoot,
+      '~~': projectRoot,
+      '@@': projectRoot,
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add a Vitest configuration to load tsconfig paths
- define Nuxt alias mappings so Vitest can resolve imports such as ~/assets/css/tailwind.css

## Testing
- npx vitest --run *(fails: vitest package is not installed in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d3eafed2508326a19e22752759a7d1