### PR TITLE
fix: register component index for markdown

### DIFF
--- a/components/content/ComponentIndex.vue
+++ b/components/content/ComponentIndex.vue
@@ -51,8 +51,8 @@
 
 <script setup lang="ts">
 import type { QueryBuilderParams } from "@nuxt/content";
-import InspiraCarbonAds from "./InspiraCarbonAds.vue";
-import {CardSpotlight} from "../inspira/ui/card-spotlight";
+import InspiraCarbonAds from "./common/InspiraCarbonAds.vue";
+import { CardSpotlight } from "./inspira/ui/card-spotlight";
 
 interface Badge {
   type: "default" | "info" | "warning" | "success" | "danger" | "lime" | undefined;


### PR DESCRIPTION
## Summary
- move `ComponentIndex` into the content components root so Nuxt Content can resolve it from markdown
- fix the component's internal imports after the move so ads and spotlight widgets still render

## Testing
- `pnpm lint` *(fails: network restriction prevents downloading pnpm 10.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f2bf737c8326b43e5f775a00f031